### PR TITLE
nvim: support 4-backtick markdown fence autopairs

### DIFF
--- a/nvim/dot-config/nvim/lua/plugins/editing.lua
+++ b/nvim/dot-config/nvim/lua/plugins/editing.lua
@@ -11,6 +11,18 @@ return {
         map = "<C-e>",
       },
     },
+    config = function(_, opts)
+      local npairs = require("nvim-autopairs")
+      local Rule = require("nvim-autopairs.rule")
+      local cond = require("nvim-autopairs.conds")
+
+      npairs.setup(opts)
+
+      npairs.add_rule(
+        Rule("```", "`", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc", "quarto", "typst" })
+          :with_pair(cond.after_text("```"))
+      )
+    end,
   },
   {
     "johmsalas/text-case.nvim",


### PR DESCRIPTION
## Summary
- extend `nvim-autopairs` setup in Neovim config to add a markdown-specific rule for 4-backtick fences
- keep existing 3-backtick behavior intact while enabling auto-pairing from ``` to ````
- apply the rule to markdown-like filetypes already used by the default markdown fence rule