### PR TITLE
nvim: read copilot toggle from NVIM_COPILOT_ENABLED

### DIFF
--- a/nvim/dot-config/nvim/lua/config/options.lua
+++ b/nvim/dot-config/nvim/lua/config/options.lua
@@ -17,3 +17,5 @@ vim.opt.cmdheight = 0
 vim.opt.ignorecase = true
 vim.opt.smartcase = true
 vim.opt.wrapscan = true
+
+vim.g.copilot_enabled = 0

--- a/nvim/dot-config/nvim/lua/config/options.lua
+++ b/nvim/dot-config/nvim/lua/config/options.lua
@@ -18,4 +18,5 @@ vim.opt.ignorecase = true
 vim.opt.smartcase = true
 vim.opt.wrapscan = true
 
-vim.g.copilot_enabled = 0
+local copilot_env = vim.env.NVIM_COPILOT_ENABLED
+vim.g.copilot_enabled = (copilot_env == "1") and 1 or 0

--- a/nvim/dot-config/nvim/lua/plugins/copilot.lua
+++ b/nvim/dot-config/nvim/lua/plugins/copilot.lua
@@ -1,5 +1,6 @@
 return {
   "zbirenbaum/copilot.lua",
+  enabled = vim.g.copilot_enabled == 1,
   cmd = "Copilot",
   build = ":Copilot auth",
   event = "BufReadPost",

--- a/nvim/dot-config/nvim/lua/plugins/editing.lua
+++ b/nvim/dot-config/nvim/lua/plugins/editing.lua
@@ -11,6 +11,18 @@ return {
         map = "<C-e>",
       },
     },
+    config = function(_, opts)
+      local npairs = require("nvim-autopairs")
+      local Rule = require("nvim-autopairs.rule")
+      local cond = require("nvim-autopairs.conds")
+
+      npairs.setup(opts)
+
+      npairs.add_rule(
+        Rule("```", "`", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc", "quarto", "typst" })
+          :with_pair(cond.after_text("```"))
+      )
+    end,
   },
   {
     "johmsalas/text-case.nvim",

--- a/nvim/dot-config/nvim/lua/plugins/nvim-cmp.lua
+++ b/nvim/dot-config/nvim/lua/plugins/nvim-cmp.lua
@@ -26,8 +26,11 @@ return {
      -- loads vscode style snippets from installed plugins (e.g. friendly-snippets)
      require("luasnip.loaders.from_vscode").lazy_load()
 
-     -- setup copilot_cmp
-     require("copilot_cmp").setup()
+    local copilot_enabled = vim.g.copilot_enabled == 1
+
+    if copilot_enabled then
+      require("copilot_cmp").setup()
+    end
 
      cmp.setup({
       snippet = { -- configure how nvim-cmp interacts with snippet engine
@@ -44,13 +47,15 @@ return {
         ["<CR>"] = cmp.mapping.confirm({ select = false }),
       }),
       -- sources for autocompletion
-      sources = cmp.config.sources({
-        { name = "copilot", group_index = 2 },
-        { name = "nvim_lsp", group_index = 2 },
-        { name = "luasnip", group_index = 2 }, -- snippets
-        { name = "buffer", group_index = 2 }, -- text within current buffer
-        { name = "path", group_index = 2 }, -- file system paths
-      }),
+      sources = cmp.config.sources(vim.list_extend(
+        copilot_enabled and { { name = "copilot", group_index = 2 } } or {},
+        {
+          { name = "nvim_lsp", group_index = 2 },
+          { name = "luasnip", group_index = 2 }, -- snippets
+          { name = "buffer", group_index = 2 }, -- text within current buffer
+          { name = "path", group_index = 2 }, -- file system paths
+        }
+      )),
 
       -- configure lspkind for vs-code like pictograms in completion menu
       formatting = {


### PR DESCRIPTION
## Summary
- Read `vim.g.copilot_enabled` from environment variable `NVIM_COPILOT_ENABLED` in Neovim options.
- Default to disabled unless the environment variable is explicitly set to `1`.
- Keep existing Copilot and cmp plugin gate logic unchanged (`vim.g.copilot_enabled == 1`).